### PR TITLE
start/stop trace on start/stop fast_server

### DIFF
--- a/src/fast_server.erl
+++ b/src/fast_server.erl
@@ -26,6 +26,7 @@ root() ->
 	end.
 
 init([]) ->
+        ftrc:start(),
 	
 	Source = "172.27.129.77",
 	Port = "24027",
@@ -78,5 +79,6 @@ handle_info(_Info, State) ->
 	{noreply, State}.
 
 terminate(normal, State) ->
+        ftrc:stop(),
 	{noreply, State}.
 

--- a/src/ftrc.erl
+++ b/src/ftrc.erl
@@ -1,0 +1,64 @@
+%%% call start/0 from the suitable place. Call stop/0 from the suitable place,
+%%% like terminate.
+%%% Convert binary trace to text:
+%%% run from console
+%%% erl -eval 'dbg:trace_client(file, "xxx")' > xxx.txt
+%%% wait till xxx.txt stops growing, then type in the console:
+%%% init:stop().
+%%% And start staring into the trace
+
+-module(ftrc).
+
+-export([
+         start/0,
+         stop/0
+        ]).
+
+start() ->
+    Base = get_name(),
+    Size = 102400000,
+    F = dbg:trace_port(file, {Base, wrap, ".trc", Size}),
+    dbg:tracer(port, F),
+    dbg:p(all, [c]),
+    Match = get_match(),
+    Mods = get_modules(),
+    [dbg:tpl(X, Match) || X <- Mods].
+
+stop() ->
+    dbg:ctpl(),
+    dbg:flush_trace_port(),
+    dbg:stop_clear().
+
+get_modules() ->
+    [
+     fast_app,
+     fast_decode_types,
+     fast_dicts,
+     fast_field_decode,
+     fast_sample,
+     fast_segment,
+     fast_server,
+     fast_sup,
+     fast_templates,
+     fast_utils,
+     fast_xml,
+     fast_xml_utils
+    ].
+
+get_name() ->
+    {A, B, _} = now(),
+    N = A * 1000000 + B,
+    Name = lists:flatten(io_lib:format("~p-~B", [?MODULE, N])),
+    filename:join("/tmp", Name).
+
+get_match() ->
+    %% or do from the erlang shell something complex, like this:
+    %% dbg:fun2ms(fun([["Packet \"Id\": " | _],_,_]) ->
+    %%                    true;
+    %%               (_) ->
+    %%                    message(false)
+    %%            end).
+    %% and write the resulting matching here:
+    [{'_',[],[true,{return_trace}]}].
+
+


### PR DESCRIPTION
предлагаю следующее:
1 - включить трейс и послать на fast сервер (это который падает) один образец данных. Сколько там будет udp пакетов - не знаю. Трассировка запишется в /tmp/ftrc-xxxxxx.trc
2 - перезапустить приложение, включить другой трейс и послать на работающий (и не падающий) сервер один образец данных.
А потом сравнить трассировки.
В принципе перезапускать приложение не обязательно, если запускать и останавливать трассировку руками - ftrc:start(), ftrc:stop().
PS: текущий снапшот кода - не компилируется. Не хватает fast_segment:encode/3, fast_segment:encode_fields/2.
